### PR TITLE
Use alternative method to find vstest.console

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -68,7 +68,7 @@ function run() {
 run();
 function FindVSTest(pathToVSWhere) {
     return __awaiter(this, void 0, void 0, function* () {
-        var vsTestPath = "";
+        let vsTestPath = "";
         const options = {};
         options.listeners = {
             stdout: (data) => {
@@ -78,10 +78,11 @@ function FindVSTest(pathToVSWhere) {
         };
         // Run VSWhere to tell us where VSTest.Console is
         var vsWhereExe = path.join(pathToVSWhere, "vswhere.exe");
-        yield exec.exec(vsWhereExe, ['-latest', '-requires', 'Microsoft.VisualStudio.Workload.ManagedDesktop', '-find', '**\\TestPlatform\\vstest.console.exe'], options);
+        yield exec.exec(vsWhereExe, ['-latest', '-products', '*', '-requires', 'Microsoft.VisualStudio.Workload.ManagedDesktop', 'Microsoft.VisualStudio.Workload.Web', '-requiresAny', '-property', 'installationPath'], options);
         if (vsTestPath === "") {
             core.setFailed("Unable to find VSTest.Console.exe");
         }
+        vsTestPath = path.join(vsTestPath.trimRight(), '\\Common7\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe');
         var folderForVSTest = path.dirname(vsTestPath);
         core.debug(`VSTest = ${vsTestPath}`);
         core.debug(`Folder for VSTest ${folderForVSTest}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -65,7 +65,7 @@ run();
 
 async function FindVSTest(pathToVSWhere:string):Promise<string>{
 
-  var vsTestPath = "";
+  let vsTestPath = "";
 
   const options:ExecOptions = {};
   options.listeners = {
@@ -77,11 +77,13 @@ async function FindVSTest(pathToVSWhere:string):Promise<string>{
 
   // Run VSWhere to tell us where VSTest.Console is
   var vsWhereExe = path.join(pathToVSWhere, "vswhere.exe");
-  await exec.exec(vsWhereExe, ['-latest', '-requires', 'Microsoft.VisualStudio.Workload.ManagedDesktop', '-find', '**\\TestPlatform\\vstest.console.exe'], options);
+  await exec.exec(vsWhereExe, ['-latest', '-products', '*', '-requires', 'Microsoft.VisualStudio.Workload.ManagedDesktop', 'Microsoft.VisualStudio.Workload.Web', '-requiresAny', '-property', 'installationPath'], options);
 
   if(vsTestPath === ""){
     core.setFailed("Unable to find VSTest.Console.exe");
   }
+
+  vsTestPath = path.join(vsTestPath.trimRight(), '\\Common7\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe')
 
   var folderForVSTest = path.dirname(vsTestPath)
   core.debug(`VSTest = ${vsTestPath}`);


### PR DESCRIPTION
Changed to use the documented method for vswhere https://github.com/Microsoft/vswhere/wiki/Find-VSTest

Test run with comparison to v1 https://github.com/feinoujc/actions-test/runs/371002610

Fixes #2 